### PR TITLE
add githubfollowers to view

### DIFF
--- a/app/controllers/users/dashboard_controller.rb
+++ b/app/controllers/users/dashboard_controller.rb
@@ -1,8 +1,12 @@
 class Users::DashboardController < ApplicationController
+
   def index
     if current_user.github_token
       search_facade = SearchFacade.new
-      @repos = search_facade.get_repos(current_user).first(5)
+      @github_data = Hash.new
+      @github_data[:repos] = search_facade.get_repos(current_user).first(5)
+      @github_data[:followers] = search_facade.get_followers(current_user)
     end
   end
+
 end

--- a/app/facades/search_facade.rb
+++ b/app/facades/search_facade.rb
@@ -1,9 +1,18 @@
 class SearchFacade
+
   def get_repos(user)
     service = GithubService.new
     repo_data = service.get_repo_data(user)
     repo_data.map do |repo_attributes|
       Repo.new(repo_attributes)
+    end
+  end
+
+  def get_followers(user)
+    service = GithubService.new
+    follower_data = service.get_follower_data(user)
+    follower_data.map do |follower_attributes|
+      Follower.new(follower_attributes)
     end
   end
 end

--- a/app/models/follower.rb
+++ b/app/models/follower.rb
@@ -1,0 +1,11 @@
+class Follower
+  attr_reader :handle, :link
+
+  def initialize(attributes)
+    @handle = attributes[:login]
+    @link = attributes[:html_url]
+  end
+
+# get_follower_data(user)
+
+end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -4,6 +4,11 @@ class GithubService
     JSON.parse(response.body, symbolize_names:true)
   end
 
+  def get_follower_data(user)
+    response = conn(user).get("/user/followers")
+    JSON.parse(response.body, symbolize_names:true)
+  end
+
   private
 
     def conn(user)

--- a/app/views/users/dashboard/index.html.erb
+++ b/app/views/users/dashboard/index.html.erb
@@ -10,12 +10,26 @@
   <section>
     <h1>Bookmarked Segments</h1>
   </section>
-  <% if @repos %>
+
+  <% if current_user.github_token %>
     <section id='github'>
-      <h1>Github Repositories</h1>
-      <% @repos.each do |repo| %>
-        <p class='github_link'><%= link_to repo.name, repo.link %></p>
+
+      <section id="repos">
+        <h1>Github Repositories</h1>
+        <% @github_data[:repos].each do |repo| %>
+          <p class='github_link'><%= link_to repo.name, repo.link %></p>
+        <% end %>
+      </section>
+
+      <% if @github_data[:followers] %>
+        <section id="followers">
+          <h1>Github Followers</h1>
+          <% @github_data[:followers].each do |follower| %>
+            <p class='github_link'><%= link_to follower.handle, follower.link %></p>
+          <% end %>
+        </section>
       <% end %>
     </section>
   <% end %>
+
 </section>

--- a/spec/features/user/user_can_see_github_followers_spec.rb
+++ b/spec/features/user/user_can_see_github_followers_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe 'User' do
+  describe 'with a github token:' do
+    before(:each) do
+      user = create(:user, github_token: ENV['GITHUB_TOKEN'])
+      create(:user, github_token: ENV['GITHUB_TOKEN_2'])
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit '/dashboard'
+    end
+
+    it 'can see all github followers', :vcr do
+      save_and_open_page
+      within('#github') do
+        within('#followers') do
+          expect(page).to have_css('.github_link', count: 2)
+          expect(page).to have_link('rcallen89')
+          expect(page).to have_link('iEv0lv3')
+        end
+      end
+    end
+  end
+end

--- a/spec/features/user/user_can_see_github_repos_spec.rb
+++ b/spec/features/user/user_can_see_github_repos_spec.rb
@@ -12,19 +12,23 @@ describe 'User' do
 
     it 'can see links for 5 github repos', :vcr do
       within('#github') do
-        expect(page).to have_css('.github_link', count: 5)
-        expect(page).to have_link('mod-0')
-        expect(page).to have_link('backend_module_0_capstone')
-        expect(page).to have_link('git_homework')
-        expect(page).to have_link('best_animals')
-        expect(page).to have_link('git_and_gh_practice')
+        within('#repos') do
+          expect(page).to have_css('.github_link', count: 5)
+          expect(page).to have_link('mod-0')
+          expect(page).to have_link('backend_module_0_capstone')
+          expect(page).to have_link('git_homework')
+          expect(page).to have_link('best_animals')
+          expect(page).to have_link('git_and_gh_practice')
+        end
       end
     end
 
     it "can not see another user's github repos", :vcr do
       within('#github') do
-        expect(page).to_not have_link('hello-world')
-        expect(page).to_not have_link('Mod0-S3-Practice')
+        within('#repos') do
+          expect(page).to_not have_link('hello-world')
+          expect(page).to_not have_link('Mod0-S3-Practice')
+        end
       end
     end
   end


### PR DESCRIPTION
## Description

Resolves #13 User Dashboard: Github Followers

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes
Created Follower Class 
added testing and methods to retrieve github followers and show them at the user/dashboard/index view



## RSpec Results
32 examples, 0 failures

Coverage report generated for RSpec 225 / 287 LOC (78.4%) covered.
