### PR TITLE
Da/email invitations

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,0 +1,14 @@
+class Users::InvitationsController < ApplicationController
+  def new
+
+  end
+
+  def create
+    search_facade = SearchFacade.new(current_user)
+    invitee = search_facade.get_user_email(params[:github_handle])
+    # happy path
+      # UserMailer.registration_invitation(current_user, invitee).deliver
+      flash[:success] = "Successfully sent invite!"
+    redirect_to dashboard_path
+  end
+end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,6 +1,5 @@
 class Users::InvitationsController < ApplicationController
   def new
-
   end
 
   def create

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -5,10 +5,13 @@ class Users::InvitationsController < ApplicationController
 
   def create
     search_facade = SearchFacade.new(current_user)
-    invitee = search_facade.get_user_email(params[:github_handle])
-    # happy path
-      # UserMailer.registration_invitation(current_user, invitee).deliver
+    invitee = search_facade.get_user(params[:github_handle])
+    if invitee.email
+      UserMailer.registration_invitation(current_user, invitee).deliver
       flash[:success] = "Successfully sent invite!"
+    else
+      flash[:error] = "The Github user you selected doesn't have an email address associated with their account."
+    end
     redirect_to dashboard_path
   end
 end

--- a/app/facades/search_facade.rb
+++ b/app/facades/search_facade.rb
@@ -25,4 +25,9 @@ class SearchFacade
       Follower.new(followed_attributes)
     end
   end
+
+  def get_user_email(user_handle)
+    user_data = @service.get_user_data(@user, user_handle)
+    user_data[:email]
+  end
 end

--- a/app/facades/search_facade.rb
+++ b/app/facades/search_facade.rb
@@ -26,8 +26,8 @@ class SearchFacade
     end
   end
 
-  def get_user_email(user_handle)
+  def get_user(user_handle)
     user_data = @service.get_user_data(@user, user_handle)
-    user_data[:email]
+    GithubUser.new(user_data)
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,4 +3,10 @@ class UserMailer < ApplicationMailer
     @user = user
     mail(to: user.email, subject: "Register your Turing Tutorials account!")
   end
+
+  def registration_invitation(sender, invitee)
+    @sender = sender
+    @invitee = invitee
+    mail(to: invitee.email, subject: "#{sender.first_name} has invited you to join Turing Tutorials!")
+  end
 end

--- a/app/poros/github_user.rb
+++ b/app/poros/github_user.rb
@@ -1,0 +1,8 @@
+class GithubUser
+  attr_reader :email, :name
+
+  def initialize(attributes)
+    @email = attributes[:email]
+    @name = attributes[:name]
+  end
+end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -11,6 +11,10 @@ class GithubService
     get_json(user, "/user/following")
   end
 
+  def get_user_data(user, username)
+    get_json(user, "/users/#{username}")
+  end
+
   private
 
     def get_json(user, url)

--- a/app/views/user_mailer/registration_invitation.html.erb
+++ b/app/views/user_mailer/registration_invitation.html.erb
@@ -1,0 +1,3 @@
+Hello <%= @invitee.name %>,
+
+<%= @sender.first_name %> has invited you to join Turing Tutorials. You can create an account <%= link_to "here", register_url %>.

--- a/app/views/user_mailer/registration_invitation.text.erb
+++ b/app/views/user_mailer/registration_invitation.text.erb
@@ -1,0 +1,3 @@
+Hello <%= @invitee.name %>,
+
+<%= @sender.first_name %> has invited you to join Turing Tutorials. You can create an account <%= link_to "here", register_url %>.

--- a/app/views/users/dashboard/index.html.erb
+++ b/app/views/users/dashboard/index.html.erb
@@ -2,6 +2,7 @@
   <h1> <%= current_user.first_name %>'s Dashboard </h1>
 
   <%= link_to 'Connect to GitHub', github_login_path, class: "btn btn-primary mb1 bg-teal" %>
+  <%= link_to 'Send an Invite', '/invite', class: "btn btn-primary mb1 bg-teal" %>
   <%= button_to 'Log Out', logout_path, method: 'delete', class: "btn btn-primary mb1 bg-teal" %>
   <h3>Account Details</h3>
   <ul>

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -1,0 +1,6 @@
+<%= form_tag :invite, method: :post do %>
+
+  <%= text_field_tag(:github_handle) %>
+  <%= submit_tag "Send Invite", class: "btn btn-primary" %>
+
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,4 +49,7 @@ Rails.application.routes.draw do
   end
 
   resources :user_videos, only:[:create, :destroy]
+
+  get '/invite', to: 'users/invitations#new'
+  post '/invite', to: 'users/invitations#create'
 end

--- a/spec/features/user/user_can_send_email_invitations_spec.rb
+++ b/spec/features/user/user_can_send_email_invitations_spec.rb
@@ -9,6 +9,7 @@ describe 'Registered user' do
     followers_json = File.read('spec/fixtures/github_followers.json')
     following_json = File.read('spec/fixtures/github_following.json')
     user_json = File.read('spec/fixtures/github_user.json')
+    user_json_2 = File.read('spec/fixtures/github_user_2.json')
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
     requests = ['repos?direction=asc&sort=created', 'followers', 'following']
@@ -24,20 +25,33 @@ describe 'Registered user' do
       .with(headers: {"Authorization" => "token #{user.github_token}"})
       .to_return(status: 200, body: user_json)
 
-    visit dashboard_path
-  end
+    stub_request(:get, "https://api.github.com/users/i-dont-exist")\
+      .with(headers: {"Authorization" => "token #{user.github_token}"})
+      .to_return(status: 200, body: user_json_2)
 
-  it "can send email invitations" do
+    visit dashboard_path
+
     click_link "Send an Invite"
 
     expect(current_path).to eq('/invite')
+  end
 
+  it 'can send email invitations' do
     fill_in 'github_handle', with: 'test-user'
     click_button('Send Invite')
 
     expect(current_path).to eq(dashboard_path)
 
     expect(page).to have_content("Successfully sent invite!")
+  end
+
+  it 'gets feedback when sending invitation to invalid account' do
+    fill_in 'github_handle', with: 'i-dont-exist'
+    click_button('Send Invite')
+
+    expect(current_path).to eq(dashboard_path)
+
+    expect(page).to have_content("The Github user you selected doesn't have an email address associated with their account.")
   end
 
 end

--- a/spec/features/user/user_can_send_email_invitations_spec.rb
+++ b/spec/features/user/user_can_send_email_invitations_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe 'Registered user' do
+  before(:each) do
+    user = create(:user, github_token: '123')
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    repo_json = File.read('spec/fixtures/github_repos.json')
+    followers_json = File.read('spec/fixtures/github_followers.json')
+    following_json = File.read('spec/fixtures/github_following.json')
+    user_json = File.read('spec/fixtures/github_user.json')
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    requests = ['repos?direction=asc&sort=created', 'followers', 'following']
+    responses = [repo_json, followers_json, following_json]
+
+    requests.zip(responses).each do |request, response_body|
+      stub_request(:get, "https://api.github.com/user/#{request}")\
+        .with(headers: {"Authorization" => "token #{user.github_token}"})
+        .to_return(status: 200, body: response_body)
+    end
+
+    stub_request(:get, "https://api.github.com/users/test-user")\
+      .with(headers: {"Authorization" => "token #{user.github_token}"})
+      .to_return(status: 200, body: user_json)
+
+    visit dashboard_path
+  end
+
+  it "can send email invitations" do
+    click_link "Send an Invite"
+
+    expect(current_path).to eq('/invite')
+
+    fill_in 'github_handle', with: 'test-user'
+    click_button('Send Invite')
+
+    expect(current_path).to eq(dashboard_path)
+
+    expect(page).to have_content("Successfully sent invite!")
+  end
+
+end

--- a/spec/features/user/user_can_send_email_invitations_spec.rb
+++ b/spec/features/user/user_can_send_email_invitations_spec.rb
@@ -8,6 +8,7 @@ describe 'Registered user' do
     repo_json = File.read('spec/fixtures/github_repos.json')
     followers_json = File.read('spec/fixtures/github_followers.json')
     following_json = File.read('spec/fixtures/github_following.json')
+
     user_json = File.read('spec/fixtures/github_user.json')
     user_json_2 = File.read('spec/fixtures/github_user_2.json')
 

--- a/spec/fixtures/github_user.json
+++ b/spec/fixtures/github_user.json
@@ -1,0 +1,14 @@
+{
+    "login": "test-user",
+    "id": 12340987,
+    "url": "https://api.github.com/users/test-user",
+    "html_url": "https://github.com/test-user",
+    "type": "User",
+    "name": "Test User",
+    "company": null,
+    "blog": "",
+    "location": "Denver, CO",
+    "email": "test-user@example.com",
+    "hireable": null,
+    "bio": null
+}

--- a/spec/fixtures/github_user_2.json
+++ b/spec/fixtures/github_user_2.json
@@ -1,0 +1,14 @@
+{
+    "login": "i-dont-exist",
+    "id": 12340987,
+    "url": "https://api.github.com/users/i-dont-exist",
+    "html_url": "https://github.com/i-dont-exist",
+    "type": "User",
+    "name": "well i do but I dont have email",
+    "company": null,
+    "blog": "",
+    "location": "Denver, CO",
+    "email": null,
+    "hireable": null,
+    "bio": null
+}

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -10,5 +10,15 @@ RSpec.describe UserMailer, type: :mailer do
       expect(email.subject).to eq('Register your Turing Tutorials account!')
       expect(email.body.encoded).to have_link('here', href: "http://test.example.com/users/#{user.id}/activate?token=#{user.confirmation_token}")
     end
+
+    it 'registration_invitation' do
+      user = create(:user)
+      invitee = GithubUser.new(email: 'invite_me@example.com', name: 'Invitee')
+      email = UserMailer.registration_invitation(user, invitee).deliver_now
+      expect(email.to).to eq([invitee.email])
+      expect(email.from).to eq(['no_reply@example.com'])
+      expect(email.subject).to eq("#{user.first_name} has invited you to join Turing Tutorials!")
+      expect(email.body.encoded).to have_link('here', href: "http://test.example.com/register")
+    end
   end
 end

--- a/spec/models/github_user_spec.rb
+++ b/spec/models/github_user_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe GithubUser, type: :model do
+  describe 'instantiation' do
+    it 'attributes' do
+      attributes = {name: 'Keagan', email: 'keagan@example.com'}
+      user = GithubUser.new(attributes)
+
+      expect(user.name).to eq('Keagan')
+      expect(user.email).to eq('keagan@example.com')
+    end
+  end
+end


### PR DESCRIPTION
## Description
Resolves #6 Email invitations

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes
Adds `UserMailer#registration_invitation` - email to invite someone to register on Turing Tutorials

Adds service/facade methods to get a github user's name and email

Adds `GithubUser` poro to store that name and email

## RSpec Results
```
60 examples, 0 failures

Coverage report generated for RSpec - 303 / 361 LOC (83.93%) covered.
```
